### PR TITLE
Debug info and temperature update

### DIFF
--- a/MHZ.cpp
+++ b/MHZ.cpp
@@ -153,7 +153,7 @@ int MHZ::readCO2UART() {
 
   // Is always 0 for version 14a  and 19b
   // Version 19a?: status != 0x40
-  if (debug || status != 0) {
+  if (debug && status != 0) {
     Serial.print(F(" ! Status maybe not OK ! "));
     Serial.println(status, HEX);
   } else if (debug) {
@@ -166,7 +166,7 @@ int MHZ::readCO2UART() {
 }
 
 uint8_t MHZ::getLastTemperature() {
-  if (!isReady()) return STATUS_NOT_READY;
+  if (isPreHeating()) return STATUS_NOT_READY;
   return temperature;
 }
 


### PR DESCRIPTION
Prevent "...Status maybe not OK.." from always being printed when debug is on.
Changed the is !isReady check to isPreHeating when getting the latest temperature. The isReady check prevents the function from returing the pre stored temperature within MHZxxx_RESPONSE_TIME after the UART data has been requested. This is an unnecessary restriction.