### PR TITLE
Correction

### DIFF
--- a/MHZ.cpp
+++ b/MHZ.cpp
@@ -243,7 +243,7 @@ int MHZ::readCO2PWM() {
     if (debug) Serial.print(".");
     th = pulseIn(_pwmpin, HIGH, 1004000) / 1000;
     tl = 1004 - th;
-    ppm_pwm = 5000 * (th - 2) / (th + tl - 4);
+    ppm_pwm = 2000 * (th - 2) / (th + tl - 4);
   } while (th == 0);
   if (debug) {
     Serial.print(F("\n # PPM PWM: "));


### PR DESCRIPTION
The datasheet clearly says that the CO2 level is 2000x(th-2ms)/(th+tl+4ms), so I think here it should say 2000 too. At least that resulted in way better results for me.

[DATASHEET ](https://www.winsen-sensor.com/d/files/infrared-gas-sensor/mh-z19b-co2-ver1_0.pdf)page 6