### PR TITLE
added upper L for Arduino Uno to preheating time

### DIFF
--- a/MHZ.cpp
+++ b/MHZ.cpp
@@ -8,8 +8,8 @@
 const int MHZ14A = 14;
 const int MHZ19B = 19;
 
-const unsigned long MHZ14A_PREHEATING_TIME = 3 * 60 * 1000;
-const unsigned long MHZ19B_PREHEATING_TIME = 3 * 60 * 1000;
+const unsigned long MHZ14A_PREHEATING_TIME = 3L * 60L * 1000L;
+const unsigned long MHZ19B_PREHEATING_TIME = 3L * 60L * 1000L;
 
 const unsigned long MHZ14A_RESPONSE_TIME = 60 * 1000;
 const unsigned long MHZ19B_RESPONSE_TIME = 120 * 1000;


### PR DESCRIPTION
The literals for the preheating time are interpreted as int.
On Arduino Uno an int is 2 bytes in size, ranging from -32,768 to 32,767. Therefore, the calculated number of 3*60*1000=180000 does not fit in.
Added upper L to force the literal to long.