### PR TITLE
Move global variables to class atributes to make it possible to define 2 sensors running independantly

### DIFF
--- a/MHZ.cpp
+++ b/MHZ.cpp
@@ -24,11 +24,6 @@ const int STATUS_NOT_READY = -5;
 const int STATUS_PWM_NOT_CONFIGURED = -6;
 const int STATUS_SERIAL_NOT_CONFIGURED = -7;
 
-unsigned long lastRequest = 0;
-
-bool SerialConfigured = true;
-bool PwmConfigured = true;
-
 MHZ::MHZ(uint8_t rxpin, uint8_t txpin, uint8_t pwmpin, uint8_t type) {
   SoftwareSerial * ss = new SoftwareSerial(rxpin, txpin);
   _pwmpin = pwmpin;

--- a/MHZ.h
+++ b/MHZ.h
@@ -52,6 +52,11 @@ class MHZ {
 
   Stream * _serial;
   byte getCheckSum(byte *packet);
+
+  unsigned long lastRequest = 0;
+
+  bool SerialConfigured = true;
+  bool PwmConfigured = true;
 };
 
 #endif


### PR DESCRIPTION
There are 3 state variables that are defined globaly in the cpp:

```
  unsigned long lastRequest = 0;

  bool SerialConfigured = true;
  bool PwmConfigured = true;
```

If you try to run 2 sensors connected to the same microcontroller, both instances of the class modify the same global variables and they go crazy.

Those variables should be local to each object of the class so they can work independantly. I moved them as private atributes of the class and it's working fine now.