### PR TITLE
Fix constructor memory leak problem and Simplify MHZ ctors with C++11 syntax

### DIFF
--- a/MHZ.cpp
+++ b/MHZ.cpp
@@ -24,18 +24,15 @@ const int STATUS_NOT_READY = -5;
 const int STATUS_PWM_NOT_CONFIGURED = -6;
 const int STATUS_SERIAL_NOT_CONFIGURED = -7;
 
-MHZ::MHZ(uint8_t rxpin, uint8_t txpin, uint8_t pwmpin, uint8_t type) {
+MHZ::MHZ(uint8_t rxpin, uint8_t txpin, uint8_t pwmpin, uint8_t type):_pwmpin(pwmpin), _type(type) {
   SoftwareSerial * ss = new SoftwareSerial(rxpin, txpin);
-  _pwmpin = pwmpin;
-  _type = type;
 
   ss->begin(9600);
   _serial = ss;
 }
 
-MHZ::MHZ(uint8_t rxpin, uint8_t txpin, uint8_t type) {
+MHZ::MHZ(uint8_t rxpin, uint8_t txpin, uint8_t type):_type(type) {
   SoftwareSerial * ss = new SoftwareSerial(rxpin, txpin);
-  _type = type;
 
   ss->begin(9600);
   _serial = ss;
@@ -43,23 +40,14 @@ MHZ::MHZ(uint8_t rxpin, uint8_t txpin, uint8_t type) {
   PwmConfigured = false;
 }
 
-MHZ::MHZ(uint8_t pwmpin, uint8_t type):_serial(nullptr) {
-  _pwmpin = pwmpin;
-  _type = type;
-
+MHZ::MHZ(uint8_t pwmpin, uint8_t type):_serial(nullptr), _pwmpin(pwmpin), _type(type) {
   SerialConfigured = false;
 }
 
-MHZ::MHZ(Stream * serial, uint8_t pwmpin, uint8_t type) {
-  _serial = serial;
-  _pwmpin = pwmpin;
-  _type = type;
+MHZ::MHZ(Stream * serial, uint8_t pwmpin, uint8_t type):_serial(serial), _pwmpin(pwmpin), _type(type) {
 }
 
-MHZ::MHZ(Stream * serial, uint8_t type) {
-  _serial = serial;
-  _type = type;
-
+MHZ::MHZ(Stream * serial, uint8_t type):_serial(serial), _type(type) {
   PwmConfigured = false;
 }
 

--- a/MHZ.cpp
+++ b/MHZ.cpp
@@ -43,7 +43,7 @@ MHZ::MHZ(uint8_t rxpin, uint8_t txpin, uint8_t type) {
   PwmConfigured = false;
 }
 
-MHZ::MHZ(uint8_t pwmpin, uint8_t type) {
+MHZ::MHZ(uint8_t pwmpin, uint8_t type):_serial(nullptr) {
   _pwmpin = pwmpin;
   _type = type;
 
@@ -61,6 +61,11 @@ MHZ::MHZ(Stream * serial, uint8_t type) {
   _type = type;
 
   PwmConfigured = false;
+}
+
+MHZ::~MHZ(){
+  if(_serial != nullptr)
+	  delete _serial;
 }
 
 /**

--- a/MHZ.h
+++ b/MHZ.h
@@ -32,6 +32,7 @@ class MHZ {
   MHZ(uint8_t pwmpin, uint8_t type);
   MHZ(Stream * serial, uint8_t pwmpin, uint8_t type);
   MHZ(Stream * serial, uint8_t type);
+  ~MHZ();
 
   void setDebug(boolean enable);
 


### PR DESCRIPTION
## Fix constructor memory leak problem
- In constructor, it use `new SoftwareSerial(...)`, but __doesn't__ have any `delete` operations. This may cause some __memory leak problems__ after the destructor was called, and I fixed it by setting up a dtor.
## Simplify MHZ ctors with C++11 syntax
- I use Constructor initializer list syntax to reduce the number of line. 
- Now, the constructor is cleaner but retain all its functions.
