### PR TITLE
Adds support for MH-Z14B and small additional features

### DIFF
--- a/MHZ.cpp
+++ b/MHZ.cpp
@@ -26,6 +26,10 @@ unsigned long getTimeDiff(unsigned long start, unsigned long stop) {
   return stop - start;
 }
 
+#ifndef IRAM_ATTR
+#define IRAM_ATTR
+#endif
+
 void IRAM_ATTR pulseInInterruptHandler() {
   unsigned long now = millis();
   int state = digitalRead(sPwmPin);
@@ -284,7 +288,7 @@ int MHZ::readCO2PWM() {
     th = pulseIn(_pwmpin, HIGH, 1004000) / 1000;
     tl = 1004 - th;
     ppm_pwm = _range * (th - 2) / (th + tl - 4);
-    if (getTimeDiff(start, millis()) > 90 * 1000) {  // Timeout after 90 seconds
+    if (getTimeDiff(start, millis()) > 90L * 1000) {  // Timeout after 90 seconds
       _console->print("Unable to read value. Timeout.");
       break;
     }

--- a/MHZ.cpp
+++ b/MHZ.cpp
@@ -116,7 +116,9 @@ void MHZ::setDebug(boolean enable, Stream* console) {
 }
 
 boolean MHZ::isPreHeating() {
-  if (_type == MHZ14A) {
+  if (_isBypassPreheatingCheck) {
+    return false;
+  } else if (_type == MHZ14A) {
     return millis() < (MHZ14A_PREHEATING_TIME);
   } else if (_type == MHZ14B) {
     return millis() < (MHZ14B_PREHEATING_TIME);
@@ -133,6 +135,8 @@ boolean MHZ::isPreHeating() {
 boolean MHZ::isReady() {
   if (isPreHeating()) {
     return false;
+  } else if (_isBypassResponseTimeCheck) {
+    return true;
   } else if (_type == MHZ14A) {
     return getTimeDiff(lastRequest, millis()) > MHZ14A_RESPONSE_TIME;
   } else if (_type == MHZ14B) {
@@ -277,6 +281,11 @@ int MHZ::getLastTemperature() {
 }
 
 void MHZ::setTemperatureOffset(uint8_t offset) { _temperatureOffset = offset; }
+
+void MHZ::setBypassCheck(boolean isBypassPreheatingCheck, boolean isBypassResponseTimeCheck) {
+  _isBypassPreheatingCheck = isBypassPreheatingCheck;
+  _isBypassResponseTimeCheck = isBypassResponseTimeCheck;
+}
 
 int MHZ::getLastCO2() { return sLastPwmPpm; }
 

--- a/MHZ.cpp
+++ b/MHZ.cpp
@@ -5,7 +5,8 @@
 
 #include "MHZ.h"
 
-const int MHZ14A = 14;
+const int MHZ14A = 114;
+const int MHZ14B = 214;
 const int MHZ19B = 119;
 const int MHZ19C = 219;
 
@@ -117,6 +118,8 @@ void MHZ::setDebug(boolean enable, Stream* console) {
 boolean MHZ::isPreHeating() {
   if (_type == MHZ14A) {
     return millis() < (MHZ14A_PREHEATING_TIME);
+  } else if (_type == MHZ14B) {
+    return millis() < (MHZ14B_PREHEATING_TIME);
   } else if (_type == MHZ19B) {
     return millis() < (MHZ19B_PREHEATING_TIME);
   } else if (_type == MHZ19C) {
@@ -132,6 +135,8 @@ boolean MHZ::isReady() {
     return false;
   } else if (_type == MHZ14A) {
     return getTimeDiff(lastRequest, millis()) > MHZ14A_RESPONSE_TIME;
+  } else if (_type == MHZ14B) {
+    return getTimeDiff(lastRequest, millis()) > MHZ14B_RESPONSE_TIME;
   } else if (_type == MHZ19B) {
     return getTimeDiff(lastRequest, millis()) > MHZ19B_RESPONSE_TIME;
   } else if (_type == MHZ19C) {

--- a/MHZ.cpp
+++ b/MHZ.cpp
@@ -243,7 +243,7 @@ int MHZ::readCO2UART() {
 
   int ppm_uart = 256 * (int)response[2] + response[3];
 
-  temperature = response[4] - 44;  // - 40;
+  temperature = response[4] - _temperatureOffset;
 
   byte status = response[5];
   if (debug) {
@@ -275,6 +275,8 @@ int MHZ::getLastTemperature() {
   if (isPreHeating()) return STATUS_NOT_READY;
   return temperature;
 }
+
+void MHZ::setTemperatureOffset(uint8_t offset) { _temperatureOffset = offset; }
 
 int MHZ::getLastCO2() { return sLastPwmPpm; }
 

--- a/MHZ.cpp
+++ b/MHZ.cpp
@@ -155,6 +155,20 @@ int MHZ::readCO2UART() {
     return STATUS_SERIAL_NOT_CONFIGURED;
   }
   if (!isReady()) return STATUS_NOT_READY;
+
+  // Clearing the uart reading buffer to avoid:
+  // - processing the unwanted data the sensor sends during startup
+  // - reading an old response already in the reading buffer
+  if (debug) _console->print(F("MHZ: - clearing uart reading buffer "));
+  while (_serial->available() > 0) {
+    if (debug) {
+      _console->print(" ");
+      _console->print(_serial->peek(), HEX);
+    }
+    _serial->read();
+  }
+  if (debug) _console->println();
+
   if (debug) _console->println(F("-- read CO2 uart ---"));
   byte cmd[9] = {0xFF, 0x01, 0x86, 0x00, 0x00, 0x00, 0x00, 0x00, 0x79};
   byte response[9];  // for answer

--- a/MHZ.h
+++ b/MHZ.h
@@ -48,6 +48,7 @@ class MHZ {
   int readCO2UART();
   int readCO2PWM();
   int getLastTemperature();
+  void setTemperatureOffset(uint8_t offset);
   int getLastCO2();
   void activateAsyncUARTReading();
 
@@ -64,6 +65,7 @@ class MHZ {
 
   uint8_t _pwmpin = UNUSED_PIN;
   uint8_t _type, temperature;
+  uint8_t _temperatureOffset = 44;
   MeasuringRange _range = RANGE_5K;
   boolean debug = false;
 

--- a/MHZ.h
+++ b/MHZ.h
@@ -51,6 +51,7 @@ class MHZ {
   void setTemperatureOffset(uint8_t offset);
   int getLastCO2();
   void activateAsyncUARTReading();
+  void setBypassCheck(boolean isBypassPreheatingCheck, boolean isBypassResponseTimeCheck);
 
  private:
   static const unsigned long MHZ14A_PREHEATING_TIME = 3L * 60L * 1000L;
@@ -68,6 +69,8 @@ class MHZ {
   uint8_t _temperatureOffset = 44;
   MeasuringRange _range = RANGE_5K;
   boolean debug = false;
+  boolean _isBypassPreheatingCheck = false;
+  boolean _isBypassResponseTimeCheck = false;
 
   Stream *_serial;
   Stream *_console;

--- a/MHZ.h
+++ b/MHZ.h
@@ -16,6 +16,7 @@
 
 // types of sensors.
 extern const int MHZ14A;
+extern const int MHZ14B;
 extern const int MHZ19B;
 extern const int MHZ19C;
 
@@ -27,7 +28,7 @@ extern const int STATUS_NOT_READY;
 
 class MHZ {
  public:
-  enum MeasuringRange { RANGE_2K = 2000, RANGE_5K = 5000 };
+  enum MeasuringRange { RANGE_2K = 2000, RANGE_5K = 5000, RANGE_10K = 10000, RANGE_50K = 50000 };
 
   MHZ(uint8_t rxpin, uint8_t txpin, uint8_t pwmpin, uint8_t type, MeasuringRange range = RANGE_5K);
   MHZ(uint8_t rxpin, uint8_t txpin, uint8_t type);
@@ -42,7 +43,7 @@ class MHZ {
   void setAutoCalibrate(boolean b);
   void calibrateZero();
   void setRange(int range);
-  // void calibrateSpan(int range); //only for professional use... see implementation and Dataheet.
+  // void calibrateSpan(int range); //only for professional use... see implementation and Datasheet.
 
   int readCO2UART();
   int readCO2PWM();
@@ -52,9 +53,11 @@ class MHZ {
 
  private:
   static const unsigned long MHZ14A_PREHEATING_TIME = 3L * 60L * 1000L;
+  static const unsigned long MHZ14B_PREHEATING_TIME = 1L * 30L * 1000L;
   static const unsigned long MHZ19B_PREHEATING_TIME = 3L * 60L * 1000L;
   static const unsigned long MHZ19C_PREHEATING_TIME = 1L * 60L * 1000L;
   static const unsigned long MHZ14A_RESPONSE_TIME = (unsigned long)60 * 1000;
+  static const unsigned long MHZ14B_RESPONSE_TIME = (unsigned long)0;
   static const unsigned long MHZ19B_RESPONSE_TIME = (unsigned long)120 * 1000;
   static const unsigned long MHZ19C_RESPONSE_TIME = (unsigned long)120 * 1000;
   static const int UNUSED_PIN = -1;


### PR DESCRIPTION
## Proposed Changes

- Adds support for MH-Z14B ([datasheet](https://www.winsen-sensor.com/d/files/infrared-gas-sensor/mh-z14b-co2-manual(ver1_1).pdf)) and additional ranges (taken from the [AliExpress store](https://aliexpress.com/item/1005005912491645.html)) #35 
   `MHZ co2(MH_Z14_RX, MH_Z14_TX, CO2_IN, MHZ14B, MHZ::RANGE_50K);`
- Clears UART read buffer before sending a CO2 read request to be sure to read the response of the request we will send
- Allows to change the temperature offset
 `co2.setTemperatureOffset(40);`
- Allows to bypass preheating and response time check (can help with #31)
  `co2.setBypassCheck(true, true);`

## Checklist:

- [x] I have read and understood the [contributing guidelines](CONTRIBUTING.md).
- [x] I have tested my changes, ensuring they do not introduce new issues or break existing functionality.
- [x] I have properly formatted my code using clang-format, as per the project's coding style guidelines.
