### PR TITLE
Prevents int overflow with high CO2 value in Arduino ATmega boards

### DIFF
--- a/MHZ.cpp
+++ b/MHZ.cpp
@@ -157,7 +157,7 @@ boolean MHZ::isReady() {
   }
 }
 
-int MHZ::readCO2UART() {
+int32_t MHZ::readCO2UART() {
   if (_serial == NULL) {
     if (debug) _console->println(F("-- serial is not configured"));
     return STATUS_SERIAL_NOT_CONFIGURED;
@@ -249,7 +249,7 @@ int MHZ::readCO2UART() {
     return STATUS_CHECKSUM_MISMATCH;
   }
 
-  int ppm_uart = 256 * (int)response[2] + response[3];
+  int32_t ppm_uart = 256 * (int32_t)response[2] + response[3];
 
   temperature = response[4] - _temperatureOffset;
 
@@ -291,7 +291,7 @@ void MHZ::setBypassCheck(boolean isBypassPreheatingCheck, boolean isBypassRespon
   _isBypassResponseTimeCheck = isBypassResponseTimeCheck;
 }
 
-int MHZ::getLastCO2() { return sLastPwmPpm; }
+int32_t MHZ::getLastCO2() { return sLastPwmPpm; }
 
 byte MHZ::getCheckSum(byte* packet) {
   if (_serial == NULL) {
@@ -309,7 +309,7 @@ byte MHZ::getCheckSum(byte* packet) {
   return checksum;
 }
 
-int MHZ::readCO2PWM() {
+int32_t MHZ::readCO2PWM() {
   if (_pwmpin == UNUSED_PIN) {
     if (debug) _console->println(F("-- pwm is not configured "));
     return STATUS_PWM_NOT_CONFIGURED;

--- a/MHZ.h
+++ b/MHZ.h
@@ -44,11 +44,11 @@ class MHZ {
   void setRange(int range);
   // void calibrateSpan(int range); //only for professional use... see implementation and Datasheet.
 
-  int readCO2UART();
-  int readCO2PWM();
+  int32_t readCO2UART();
+  int32_t readCO2PWM();
   int getLastTemperature();
   void setTemperatureOffset(uint8_t offset);
-  int getLastCO2();
+  int32_t getLastCO2();
   void activateAsyncUARTReading();
   void setBypassCheck(boolean isBypassPreheatingCheck, boolean isBypassResponseTimeCheck);
 
@@ -62,14 +62,14 @@ class MHZ {
   static const unsigned long MHZ19D_PREHEATING_TIME = 1L * 60L * 1000L;
   static const unsigned long MHZ19E_PREHEATING_TIME = 1L * 60L * 1000L;
 
-  static const unsigned long MHZ14A_RESPONSE_TIME = 60 * 1000;
+  static const unsigned long MHZ14A_RESPONSE_TIME = 60L * 1000L;
   static const unsigned long MHZ14B_RESPONSE_TIME = 0;
-  static const unsigned long MHZ16_RESPONSE_TIME = 30 * 1000;
-  static const unsigned long MHZ1911A_RESPONSE_TIME = 120 * 1000;
-  static const unsigned long MHZ19B_RESPONSE_TIME = 120 * 1000;
-  static const unsigned long MHZ19C_RESPONSE_TIME = 120 * 1000;
-  static const unsigned long MHZ19D_RESPONSE_TIME = 120 * 1000;
-  static const unsigned long MHZ19E_RESPONSE_TIME = 120 * 1000;
+  static const unsigned long MHZ16_RESPONSE_TIME = 30L * 1000L;
+  static const unsigned long MHZ1911A_RESPONSE_TIME = 120L * 1000L;
+  static const unsigned long MHZ19B_RESPONSE_TIME = 120L * 1000L;
+  static const unsigned long MHZ19C_RESPONSE_TIME = 120L * 1000L;
+  static const unsigned long MHZ19D_RESPONSE_TIME = 120L * 1000L;
+  static const unsigned long MHZ19E_RESPONSE_TIME = 120L * 1000L;
 
   static const int UNUSED_PIN = -1;
 

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ int ppm = co2.readCO2UART();
 ```
 
 ## Supported Sensors
-All `MH` sensors work mostly the same. They only differ in detection range and timings.  
+All `MH` sensors work mostly the same. They only differ in detection range and timings.
 Here is a list of all explicitly supported sensors:
 
 | Sensor    | Detection Range | Reference / Datasheet                                            |
 |-----------|-----------------|------------------------------------------------------|
 | MH-Z14A   | 400~10000ppm    | https://www.winsen-sensor.com/product/mh-z14a.html   |
-| MH-Z14B   | 400~10000ppm    | https://www.winsen-sensor.com/product/mh-z19b.html   |
-| MH-Z16    | 400~10000ppm    | https://www.winsen-sensor.com/product/mh-z16.html    |
+| MH-Z14B   | 400~50000ppm    | https://www.winsen-sensor.com/product/mh-z19b.html   |
+| MH-Z16    | 400~100000ppm   | https://www.winsen-sensor.com/product/mh-z16.html    |
 | MH-Z1911A | 0~10000ppm      | https://www.winsen-sensor.com/product/mh-z1911a.html |
 | MH-Z19B   | 400~10000ppm    | https://www.winsen-sensor.com/product/mh-z19b.html   |
 | MH-Z19C   | 400~10000ppm    | https://www.winsen-sensor.com/product/mh-z19c.html   |


### PR DESCRIPTION
On Arduino ATmega boards an `int` is stored on [2 bytes](https://www.arduino.cc/reference/en/language/variables/data-types/int/).
With a CO2 value above 32 768 ppm, the value returned by the library became negative.
Switched to ~~`uint32_t`~~  `int32_t`.


