### PR TITLE
fix: _serial is not initialized when debug is false

### DIFF
--- a/MHZ.cpp
+++ b/MHZ.cpp
@@ -323,7 +323,7 @@ int32_t MHZ::readCO2PWM() {
     tl = 1004 - th;
     ppm_pwm = _range * (th - 2) / (th + tl - 4);
     if (getTimeDiff(start, millis()) > 90L * 1000) {  // Timeout after 90 seconds
-      _console->print("Unable to read value. Timeout.");
+      if (debug) _console->print("Unable to read value. Timeout.");
       break;
     }
   } while (th == 0);


### PR DESCRIPTION
## Proposed Change
* fix the Panic when  _console is not initialized by adding `if (debug)` like above line.
<!--
Please provide a clear and concise description of the changes you are proposing and the problem they aim to solve.
-->

## Checklist:

- [x] I have read and understood the [contributing guidelines](CONTRIBUTING.md).
- [x] I have tested my changes, ensuring they do not introduce new issues or break existing functionality.
- [x] I have properly formatted my code using clang-format, as per the project's coding style guidelines.
